### PR TITLE
Patched "No such file or directory" issue

### DIFF
--- a/wipe-modules.sh
+++ b/wipe-modules.sh
@@ -51,7 +51,7 @@ go_gir() {
       continue
     fi
     # move to code dir subdirectory
-    cd $d
+    cd "$d"
     if [ `find . -maxdepth 1 -type d -name 'node_modules'` ]
     then
       # if $dry is not --dry (or -D) then just print the name of the folder that

--- a/wipe-modules.sh
+++ b/wipe-modules.sh
@@ -47,6 +47,9 @@ go_gir() {
   # find the code directories whose last modify time (mtime) is older than $last_modified days
   # and loop through each resulting dir
   for d in `find . -maxdepth 1 -type d -mtime +$last_modified`; do
+    if [ "$d" == "." ]; then
+      continue
+    fi
     # move to code dir subdirectory
     cd $d
     if [ `find . -maxdepth 1 -type d -name 'node_modules'` ]

--- a/wipe-modules.sh
+++ b/wipe-modules.sh
@@ -46,7 +46,7 @@ go_gir() {
 
   # find the code directories whose last modify time (mtime) is older than $last_modified days
   # and loop through each resulting dir
-  for d in `find . -maxdepth 1 -type d -mtime +$last_modified`; do
+  find . -maxdepth 1 -type d -mtime +$last_modified | while read d; do
     if [ "$d" == "." ]; then
       continue
     fi


### PR DESCRIPTION
The first result from the "for d in" loop was returning "." so I've added a clause to skip over it, which seems to fix the "No such file or directory" issue. Tag as v1.0.3? ;)